### PR TITLE
🐛 bug: `i.` sequences should start from zero

### DIFF
--- a/src/a.rs
+++ b/src/a.rs
@@ -125,7 +125,7 @@ use super::*; use std::marker::PhantomData as PD;
 /**monadic verbs*/impl A{
   pub fn m_idot(self)->R<A>{let(a@A{m,n,..})=self;let gi=|i,j|a.get(i,j)?.try_into().map_err(E::from);
     if let(1,1)=(m,n){let(m,n)=(1,gi(1,1)?);let(mut o)=A::new(1,n)?;
-      for(j)in(1..=n){o.set(1,j,j.try_into()?)?;}Ok(unsafe{o.finish()})}
+      for(j)in(1..=n){o.set(1,j,(j-1).try_into()?)?;}Ok(unsafe{o.finish()})}
     else if let(1,2)=(m,n){let(m,n)=(gi(1,1)?,gi(1,2)?);
       let(mut v)=0_u32;let(f)=move |_,_|{let(v_o)=v;v+=1;Ok(v_o)};A::new(m,n)?.init_with(f)}
     else{bail!("i. {m}x{n} not supported")}}

--- a/tests/t.rs
+++ b/tests/t.rs
@@ -20,7 +20,7 @@
     #[test]fn $f()->R<()>{let(a@A{m:1,n:1,..})=eval_s($i)? else{bail!("bad dims")};eq!(a.as_slice()?,&[$o]);ok!()}}}
   t!(tally_scalar,"# 1",1);t!(tally_1x3,"# 1 2 3",3);t!(tally_3x3,"# i. 3 3",9);
 } #[cfg(test)]mod idot{use super::*;
-  #[test]fn idot_3()->R<()>{let(a)=eval_s("i. 3")?;eq!(a.m,1);eq!(a.n,3);eq!(a.as_slice()?,&[1,2,3]);ok!()}
+  #[test]fn idot_3()->R<()>{let(a)=eval_s("i. 3")?;eq!(a.m,1);eq!(a.n,3);eq!(a.as_slice()?,&[0,1,2]);ok!()}
   #[test]fn idot_2_3()->R<()>{let(a)=eval_s("i. 2 3")?;eq!(a.m,2);eq!(a.n,3);let o:&[&[I]]=&[&[0,1,2],&[3,4,5]];
     eq!(a.into_matrix()?,o);eq!(a,o);ok!()}
   #[test]fn idot_3_2()->R<()>{let(a)=eval_s("i. 3 2")?;eq!(a.m,3);eq!(a.n,2);let o:&[&[I]]=&[&[0,1],&[2,3],&[4,5]];


### PR DESCRIPTION
this fixes a small bug for the `i.` operator, which was generating sequences `1..n`, rather than `0..n-1`.

comparing with the official J runtime for reference:

```
; jconsole
   i. 0

   i. 5
0 1 2 3 4

   i. 5 5
 0  1  2  3  4
 5  6  7  8  9
10 11 12 13 14
15 16 17 18 19
20 21 22 23 24

; cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.10s
     Running `target/debug/j`
  i. 0

  i. 5
0 1 2 3 4

  i. 5 5
0 1 2 3 4
5 6 7 8 9
10 11 12 13 14
15 16 17 18 19
20 21 22 23 24
```