### PR TITLE
👻 permit empty expressions

### DIFF
--- a/src/j.rs
+++ b/src/j.rs
@@ -2,7 +2,8 @@
 /**prelude*/mod p;use p::*;#[cfg(test)]use p::tp::*;
 /**array*/mod a; /**read input*/mod r; /**symbol table*/mod s;
 pub use self::{a::*,r::*,s::*};
-pub fn eval(input:&str,st:&mut ST)->R<O<A>>{parse(input)?.ok_or(err!("empty")).and_then(|ast|eval_(ast,st))}
+pub fn eval(input:&str,st:&mut ST)->R<O<A>>{
+  let(ast)=match(parse(input)?){Some(x)=>x,None=>rrn!()};eval_(ast,st)}
 fn eval_(ast:B<N>,st:&mut ST)->R<O<A>>{use{M::*,D::*};
   let(mut rec)=|a|->R<A>{match(eval_(a,st)){Ok(Some(a))=>Ok(a),Err(e)=>Err(e), // recursively evaluate subexpression.
     Ok(None)=>Err(err!("expression did not result in a value"))}};

--- a/src/p.rs
+++ b/src/p.rs
@@ -7,6 +7,7 @@ pub(crate)use{std::{alloc::Layout as L,clone::Clone as CL,cmp::{PartialEq as PE,
 pub(crate)use{anyhow::{Context,Error as E,anyhow as err,bail}};
 #[macro_export] /**`return`*/              macro_rules! r   {()=>{return};($e:expr)=>{return $e};}
 #[macro_export] /**`return Ok(Some(..))`*/ macro_rules! rro {($e:expr)=>{r!(Ok(Some($e)))}}
+#[macro_export] /**`return Ok(None)`*/     macro_rules! rrn {(       )=>{r!(Ok(None    ))}}
 #[macro_export] /**`Ok(())`*/              macro_rules! ok {()=>{Ok(())}}
 #[macro_export] /**`Box::new(..)`*/        macro_rules! b   {($e:expr)=>{B::new($e)};}
 #[macro_export] /**`unreachable!()`*/      macro_rules! ur  {()=>{unreachable!()}}

--- a/src/r.rs
+++ b/src/r.rs
@@ -32,7 +32,8 @@
     ok!()}
   pub(crate) fn parse(input:&str)->R<O<B<N>>>{const MAX:u32=128;let(mut ts,mut ctx,mut i)=(lex(input)?,V::new(),0);
     while(!ts.is_empty()){if(i>MAX){bail!("max iterations")}parse_(&mut ts,&mut ctx)?;i+=1;}
-    debug_assert!(ts.is_empty());debug_assert_eq!(ctx.len(),1);Ok(ctx.pop())}
+    /*debug*/debug_assert!(ts.is_empty());if(!input.trim().is_empty()){debug_assert_eq!(ctx.len(),1);}/*debug*/
+    Ok(ctx.pop())}
   impl M{fn new(s:&str)->O<M>{use M::*;Some(match s{"i."=>Idot,"$"=>Shape,"#"=>Tally,"|:"=>Transpose,_=>r!(None)})}}
   impl D{fn new(s:&str)->O<D>{use D::*;Some(match s{"+"=>Plus,"*"=>Mul,_=>r!(None)})}}
   #[cfg(test)]mod t{use super::*;
@@ -47,6 +48,6 @@
     t!(parse_symbol_times_symbol,"a * b"); t!(parse_tally_tally_symbol,"# # a");
     tf!(parse_symbol_times_symbol_numbers,"a * b 1"); tf!(parse_tally_tally_symbol_symbol,"# # a b");
     t!(assign_symbol_scalar,"a =: 1"); t!(assign_symbol_slice,"a =: 1 2 3"); t!(assign_symbol_idot,"a =: i. 2 3");
-    t!(assign_symbol_slice_plus_slice,"a =: 1 2 3 + 1 2 3");
+    t!(assign_symbol_slice_plus_slice,"a =: 1 2 3 + 1 2 3"); t!(parse_empty,"");
   }
 }

--- a/tests/t.rs
+++ b/tests/t.rs
@@ -53,6 +53,7 @@
     assert_eq!(st.get_s("a").unwrap().as_slice().unwrap(),&[3,7]);ok!()}
   // TODO: tests exercising use of variables
 } #[cfg(test)]mod misc{use super::*;
+  #[test]fn empty_statement_evaluates_to_none()->R<()>{is!(eval("",&mut ST::default())?.is_none());ok!()}
   #[test]fn slice_times_transposed_idot_2_3()->R<()>{
     let(a)=eval_s("1 2 3 * |: i. 2 3")?;eq!(a.into_matrix()?,&[&[0,3],&[2,8],&[6,15]]);ok!()}
 } #[cfg(test)]mod display{use super::*;


### PR DESCRIPTION
this commit addresses crashes that look like so, reproducible on 218b40c:

```
; cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.10s
     Running `target/debug/j`

thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `0`,
 right: `1`', src/r.rs:35:56
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

...and, after this change:

```
; cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.09s
     Running `target/debug/j`

  1 + 2
3
```

most importantly, `j::eval` will not return `Ok(None)` when given an empty input string. a new `rrn!` macro is added to the project prelude in order to return `Ok(None)`.

a debug assertion in `j::r::parse` is now guarded behind a check that the string is not only empty whitespace.