### PR TITLE
🔳 implement `[` and `]` verbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,14 @@ provided. variables may be defined.
 * `|:` "transpose" rotates its argument
 * `#` "tally" counts the elements in its argument
 * `$` "shape" returns a value containing the dimensions of its argument
+* `[` "same" returns the given value
+* `]` "same" returns the given value
 
 **dyadic verbs**
 * `+` returns the sum of its two arguments
 * `*` returns the product of its two arguments
+* `[` "left" returns the left value
+* `]` "right" returns the right value
 
 variables are assigned using `=:`. variable names may only contain lowercase ASCII `a-z`
 characters, numeric `0-9` characters, and `_` underscores. variable names must begin with a

--- a/src/a.rs
+++ b/src/a.rs
@@ -99,6 +99,7 @@ use super::*; use std::marker::PhantomData as PD;
   impl TF<&[I]> for A{type Error=E;fn try_from(s:&[I])->R<A>{
     let(m,n)=(1,s.len());let(mut a)=A::new(m,n)?;
     for(i,v)in(s.iter().enumerate()){let(i)=(i+1).try_into()?;a.set(1,i,*v)?;}Ok(unsafe{a.finish()})}}
+  impl TF<V<I>> for A{type Error=E;fn try_from(v:V<I>)->R<A>{v.as_slice().try_into()}}
   #[test]fn scalars_can_be_a_slice()->R<()>{let(a)=A::from_i(420)?;let _:&[I]=a.as_slice()?;ok!()}
   #[test]fn from_empty()->R<()>{let a:&[I]=&[];let _=A::try_from(a)?;ok!()}
   #[test]fn from_one()->R<()>{let a:&[I]=&[42];let a=A::try_from(a)?;eq!(a.get(1,1)?,42);ok!()}

--- a/src/a.rs
+++ b/src/a.rs
@@ -150,8 +150,8 @@ use super::*; use std::marker::PhantomData as PD;
       {if(s.len()==*m){let(f)=|i,j|{let(x)=a.get(i,j)?;let(y)=(s[i-1]);Ok(f(x,y))};r!(A::new(*m,*n)?.init_with(f))}}
     else if (ml==mr)&&(nl==nr){let(m,n)=(ml,nl);r!(A::new(m,n)?.init_with(                                              // matching arrays
       |i,j|{let(l,r)=(l.get(i,j)?,r.get(i,j)?);Ok(f(l,r))}))}
-    else if (ml==nr)&&(nl==mr)                                                                                          // rotation
-      {let(f)=|i,j|{let(x)=l.get(i,j)?;let(y)=r.get(j,i)?;Ok(f(x,y))};r!(A::new(ml,nl)?.init_with(f))}
+    else if (ml==nr)&&(nl==mr) /*NB: inherit the dimensions of the right-hand operand.*/                                // rotation
+      {let(f)=|i,j|{let(x)=l.get(j,i)?;let(y)=r.get(i,j)?;Ok(f(x,y))};r!(A::new(mr,nr)?.init_with(f))}
     bail!("length error");
   }
 }

--- a/src/a.rs
+++ b/src/a.rs
@@ -123,6 +123,7 @@ use super::*; use std::marker::PhantomData as PD;
 }
 
 /**monadic verbs*/impl A{
+  pub fn m_same(self)->R<A>{Ok(self)}
   pub fn m_idot(self)->R<A>{let(a@A{m,n,..})=self;let gi=|i,j|a.get(i,j)?.try_into().map_err(E::from);
     if let(1,1)=(m,n){let(m,n)=(1,gi(1,1)?);let(mut o)=A::new(1,n)?;
       for(j)in(1..=n){o.set(1,j,(j-1).try_into()?)?;}Ok(unsafe{o.finish()})}
@@ -136,6 +137,8 @@ use super::*; use std::marker::PhantomData as PD;
 }
 
 /**dyadic verbs*/impl A{
+  pub fn d_left (self,r:A)->R<A>{Ok(self)}
+  pub fn d_right(self,r:A)->R<A>{Ok(r)   }
   pub fn d_plus(self,r:A)->R<A>{A::d_do(self,r,|x,y|x+y)}
   pub fn d_mul (self,r:A)->R<A>{A::d_do(self,r,|x,y|x*y)}
   pub fn d_do(l@A{m:ml,n:nl,..}:A,r@A{m:mr,n:nr,..}:A,f:impl Fn(I,I)->I)->R<A<MI>>{

--- a/src/j.rs
+++ b/src/j.rs
@@ -9,9 +9,10 @@ fn eval_(ast:B<N>,st:&mut ST)->R<O<A>>{use{M::*,D::*};
     Ok(None)=>Err(err!("expression did not result in a value"))}};
   match *ast{
   N::A{a}    =>Ok(a),
-  N::M{m,o}  =>{let(a)=rec(o)?;            match m{Idot=>a.m_idot(),  Shape=>a.m_shape(),
+  N::M{m,o}  =>{let(a)=rec(o)?;            match m{Idot=>a.m_idot(),  Shape=>a.m_shape(), Same=>a.m_same(),
                                                    Tally=>a.m_tally(),Transpose=>a.m_trans()}}
-  N::D{d,l,r}=>{let(l,r)=(rec(r)?,rec(l)?);match d{Plus=>l.d_plus(r), Mul=>l.d_mul(r)}}
+  N::D{d,l,r}=>{let(l,r)=(rec(r)?,rec(l)?);match d{Plus=>l.d_plus(r), Mul=>l.d_mul(r),
+                                                   Left=>l.d_left(r), Right=>l.d_right(r)}}
   N::S{sy}   =>{st.get(&sy).ok_or(err!("undefined symbol: {sy:?}"))?;todo!("symbol value clone")}
   N::V{sy,e} =>{let(a)=rec(e)?;st.insert(sy,a);r!(Ok(None))}
 }.map(O::Some)}

--- a/src/j.rs
+++ b/src/j.rs
@@ -3,7 +3,7 @@
 /**array*/mod a; /**read input*/mod r; /**symbol table*/mod s;
 pub use self::{a::*,r::*,s::*};
 pub fn eval(input:&str,st:&mut ST)->R<O<A>>{
-  let(ast)=match(parse(input)?){Some(x)=>x,None=>rrn!()};eval_(ast,st)}
+  let(mut ts)=lex(input)?;let(ast)=match(parse(&mut ts)?){Some(x)=>x,None=>rrn!()};eval_(ast,st)}
 fn eval_(ast:B<N>,st:&mut ST)->R<O<A>>{use{M::*,D::*};
   let(mut rec)=|a|->R<A>{match(eval_(a,st)){Ok(Some(a))=>Ok(a),Err(e)=>Err(e), // recursively evaluate subexpression.
     Ok(None)=>Err(err!("expression did not result in a value"))}};

--- a/src/j.rs
+++ b/src/j.rs
@@ -11,7 +11,7 @@ fn eval_(ast:B<N>,st:&mut ST)->R<O<A>>{use{M::*,D::*};
   N::A{a}    =>Ok(a),
   N::M{m,o}  =>{let(a)=rec(o)?;            match m{Idot=>a.m_idot(),  Shape=>a.m_shape(), Same=>a.m_same(),
                                                    Tally=>a.m_tally(),Transpose=>a.m_trans()}}
-  N::D{d,l,r}=>{let(l,r)=(rec(r)?,rec(l)?);match d{Plus=>l.d_plus(r), Mul=>l.d_mul(r),
+  N::D{d,l,r}=>{let(l,r)=(rec(l)?,rec(r)?);match d{Plus=>l.d_plus(r), Mul=>l.d_mul(r),
                                                    Left=>l.d_left(r), Right=>l.d_right(r)}}
   N::S{sy}   =>{st.get(&sy).ok_or(err!("undefined symbol: {sy:?}"))?;todo!("symbol value clone")}
   N::V{sy,e} =>{let(a)=rec(e)?;st.insert(sy,a);r!(Ok(None))}

--- a/src/p.rs
+++ b/src/p.rs
@@ -13,7 +13,7 @@ pub(crate)use{anyhow::{Context,Error as E,anyhow as err,bail}};
 #[macro_export] /**`unreachable!()`*/      macro_rules! ur  {()=>{unreachable!()}}
 /**`Result<T, anyhow::Error>`*/            pub type R<T> = Result<T,E>;
 #[cfg(test)]/**test prelude*/pub(crate) mod tp{
-  pub(crate) use{assert_eq as eq,assert_ne as neq,assert as is};
+  pub(crate) use{assert_eq as eq,assert_ne as neq,assert as is,vec as v};
 }
 // todo: extension trait for abbreviated `try_into`, `try_from`
 // todo: extension trait for abbreviated `map`, `and_then`, `unwrap`

--- a/src/r.rs
+++ b/src/r.rs
@@ -8,9 +8,9 @@
     #[test]fn lex_1plus2()->R<()>{let ts=lex("1 + 2")?;eq!(ts.as_ref(),[T::I(1),T::V(S::from("+")),T::I(2)]);ok!()}
   }
 }/**input parsing*/pub(crate) use parse::{D,M,N,parse};mod parse{use {crate::*,super::lex::{T,lex}};
-  /**dyadic verb       */ #[derive(DBG,PE,PO)] pub enum D {Plus,Mul}
-  /**monadic verb      */ #[derive(DBG,PE,PO)] pub enum M {Idot,Shape,Tally,Transpose}
-  /**ast node          */                      pub enum N {/**array literal*/    A{a:A},
+  /**dyadic verb       */ #[derive(DBG,PE,PO)] pub enum D {Plus,Mul,  Left, Right         }
+  /**monadic verb      */ #[derive(DBG,PE,PO)] pub enum M {Idot,Shape,Tally,Transpose,Same}
+  /**ast node          */ #[derive(DBG,     )] pub enum N {/**array literal*/    A{a:A},
                                                            /**dyadic verb*/      D{d:D,l:B<N>,r:B<N>},
                                                            /**monadic verb*/     M{m:M,o:B<N>},
                                                            /**symbol*/           S{sy:SY},

--- a/src/r.rs
+++ b/src/r.rs
@@ -34,8 +34,8 @@
     while(!ts.is_empty()){if(i>MAX){bail!("max iterations")}parse_(&mut ts,&mut ctx)?;i+=1;}
     /*debug*/debug_assert!(ts.is_empty());if(!input.trim().is_empty()){debug_assert_eq!(ctx.len(),1);}/*debug*/
     Ok(ctx.pop())}
-  impl M{fn new(s:&str)->O<M>{use M::*;Some(match s{"i."=>Idot,"$"=>Shape,"#"=>Tally,"|:"=>Transpose,_=>r!(None)})}}
-  impl D{fn new(s:&str)->O<D>{use D::*;Some(match s{"+"=>Plus,"*"=>Mul,_=>r!(None)})}}
+  impl M{fn new(s:&str)->O<M>{use M::*;Some(match s{"i."=>Idot,"$"=>Shape,"#"=>Tally,"|:"=>Transpose,"["|"]"=>Same,_=>r!(None)})}}
+  impl D{fn new(s:&str)->O<D>{use D::*;Some(match s{"+"=>Plus,"*"=>Mul,"["=>Left,"]"=>Right,_=>r!(None)})}}
   #[cfg(test)]mod t{use super::*;
     macro_rules! t{($f:ident,$i:literal)=>{#[test]fn $f()->R<()>{let ast=parse($i)?;ok!()}}}
     macro_rules! tf{($f:ident,$i:literal)=>{#[test] #[should_panic]fn $f(){parse($i).unwrap();}}}

--- a/src/s.rs
+++ b/src/s.rs
@@ -1,6 +1,6 @@
 use super::*; use std::ops::Not;
-/**symbol*/      #[derive(PE,DBG,PO,Ord,Eq)]pub struct SY(S);
-/**symbol table*/#[derive(Default)]         pub struct ST{st:BM<SY,A>}
+/**symbol*/      #[derive(PE,DBG,PO,Ord,Eq,CL)]pub struct SY(S);
+/**symbol table*/#[derive(Default)]            pub struct ST{st:BM<SY,A>}
 
 /**symbol parsing*/mod syfs{use super::*;
   impl FS for SY{type Err = E;fn from_str(s:&str)->R<SY>{

--- a/tests/t.rs
+++ b/tests/t.rs
@@ -44,6 +44,15 @@
     eq!(a.into_matrix()?,&[&[0,1],&[4,6],&[12,15]]);ok!()}
   #[test]fn mult_slice_to_rotated_slice()->R<()>{
     let(a@A{m:4,n:1,..})=eval_s("1 2 3 4 * i. 4 1")? else{bail!("bad dims")};eq!(a.into_matrix()?,&[&[0],&[2],&[6],&[12]]);ok!()}
+} #[cfg(test)]mod left_and_right{use super::*;
+  #[test]fn left_same_scalar() ->R<()>{let(a)=eval_s("[ 1")?;        eq!(a.as_i()?,1);           ok!()}
+  #[test]fn left_same_slice()  ->R<()>{let(a)=eval_s("[ 1 2 3")?;    eq!(a.as_slice()?,&[1,2,3]);ok!()}
+  #[test]fn right_same_scalar()->R<()>{let(a)=eval_s("] 1")?;        eq!(a.as_i()?,1);           ok!()}
+  #[test]fn right_same_slice() ->R<()>{let(a)=eval_s("] 1 2 3")?;    eq!(a.as_slice()?,&[1,2,3]);ok!()}
+  #[test]fn left_dyad()        ->R<()>{let(a)=eval_s("1 [ 2")?;      eq!(a.as_i()?,1);           ok!()}
+  #[test]fn right_dyad()       ->R<()>{let(a)=eval_s("1 ] 2")?;      eq!(a.as_i()?,2);           ok!()}
+  #[test]fn left_dyad_other()  ->R<()>{let(a)=eval_s("1 [ 2 3 4")?;  eq!(a.as_slice()?,&[2,3,4]);ok!()}
+  #[test]fn right_dyad_other() ->R<()>{let(a)=eval_s("1 ] 2 3 4")?;  eq!(a.as_i()?,1);           ok!()}
 } #[cfg(test)]mod symbol_assignment{use super::*;
   #[test]fn assign_and_get_i()->R<()>{let(mut st)=ST::default();let(a)=eval("a =: 3",&mut st)?;
     assert_eq!(st.get_s("a").unwrap().as_i().unwrap(),3);ok!()}

--- a/tests/t.rs
+++ b/tests/t.rs
@@ -51,8 +51,8 @@
   #[test]fn right_same_slice() ->R<()>{let(a)=eval_s("] 1 2 3")?;    eq!(a.as_slice()?,&[1,2,3]);ok!()}
   #[test]fn left_dyad()        ->R<()>{let(a)=eval_s("1 [ 2")?;      eq!(a.as_i()?,1);           ok!()}
   #[test]fn right_dyad()       ->R<()>{let(a)=eval_s("1 ] 2")?;      eq!(a.as_i()?,2);           ok!()}
-  #[test]fn left_dyad_other()  ->R<()>{let(a)=eval_s("1 [ 2 3 4")?;  eq!(a.as_slice()?,&[2,3,4]);ok!()}
-  #[test]fn right_dyad_other() ->R<()>{let(a)=eval_s("1 ] 2 3 4")?;  eq!(a.as_i()?,1);           ok!()}
+  #[test]fn left_dyad_other()  ->R<()>{let(a)=eval_s("1 [ 2 3 4")?;  eq!(a.as_i()?,1);           ok!()}
+  #[test]fn right_dyad_other() ->R<()>{let(a)=eval_s("1 ] 2 3 4")?;  eq!(a.as_slice()?,&[2,3,4]);ok!()}
 } #[cfg(test)]mod symbol_assignment{use super::*;
   #[test]fn assign_and_get_i()->R<()>{let(mut st)=ST::default();let(a)=eval("a =: 3",&mut st)?;
     assert_eq!(st.get_s("a").unwrap().as_i().unwrap(),3);ok!()}


### PR DESCRIPTION
this branch implements the `[` and `]` operators, in both monadic and dyadic forms.

* `[ y` [same](https://code.jsoftware.com/wiki/Vocabulary/squarelf)
* `] y` [same](https://code.jsoftware.com/wiki/Vocabulary/squarert)
* `x [ y` [left](https://code.jsoftware.com/wiki/Vocabulary/squarelf#dyadic)
* `x ] y` [right](https://code.jsoftware.com/wiki/Vocabulary/squarert#dyadic)