### PR TITLE
monadic `>:` increment verb

### DIFF
--- a/src/a.rs
+++ b/src/a.rs
@@ -138,6 +138,7 @@ use super::*; use std::marker::PhantomData as PD;
   pub fn m_tally(self)->R<A>{let A{m,n,..}=self;let(i)=I::try_from(m*n)?;A::from_i(i)}
   pub fn m_trans(self)->R<A>{let(i@A{m:m_i,n:n_i,..})=self;let(m_o,n_o)=(n_i,m_i);
     let(f)=|i_o,j_o|{i.get(j_o,i_o)};A::new(m_o,n_o)?.init_with(f)}
+  pub fn m_inc(self)->R<A>{let(a@A{m,n,..})=self;A::new(m,n)?.init_with(|i,j|a.get(i,j).map(|x|x+1))}
 }
 
 /**dyadic verbs*/impl D{

--- a/src/j.rs
+++ b/src/j.rs
@@ -9,8 +9,8 @@ fn eval_(ast:B<N>,st:&mut ST)->R<O<A>>{use{M::*,D::*};
     Ok(None)=>Err(err!("expression did not result in a value"))}};
   match *ast{
   N::A{a}    =>Ok(a),
-  N::M{m,o}  =>{let(a)=rec(o)?;            match m{Idot=>a.m_idot(),  Shape=>a.m_shape(), Same=>a.m_same(),
-                                                   Tally=>a.m_tally(),Transpose=>a.m_trans()}}
+  N::M{m,o}  =>{let(a)=rec(o)?;            match m{Idot=>a.m_idot(),  Shape=>a.m_shape(),     Same=>a.m_same(),
+                                                   Tally=>a.m_tally(),Transpose=>a.m_trans(), Inc=>a.m_inc()}}
   N::D{d,l,r}=>{let(l,r)=(rec(l)?,rec(r)?);match d{Plus=>l.d_plus(r), Mul=>l.d_mul(r),
                                                    Left=>l.d_left(r), Right=>l.d_right(r)}}
   N::Ym{ym,d,o}=>{rec(o).and_then(|a|ym.apply(d,a))}

--- a/src/r.rs
+++ b/src/r.rs
@@ -32,8 +32,8 @@ mod lex{use crate::*;
     t!(lex_assign,    "a =: 1",       v![sy!("a"),         T::E,             TA(v![1])]                              );
   }
 }/**input parsing*/mod parse{use {crate::*,super::lex::{T,lex}};
-  /**dyadic verb       */ #[derive(DBG,PE,PO)] pub enum D {Plus,Mul,  Left, Right         }
-  /**monadic verb      */ #[derive(DBG,PE,PO)] pub enum M {Idot,Shape,Tally,Transpose,Same}
+  /**dyadic verb       */ #[derive(DBG,PE,PO)] pub enum D {Plus,Mul,  Left, Right             }
+  /**monadic verb      */ #[derive(DBG,PE,PO)] pub enum M {Idot,Shape,Tally,Transpose,Same,Inc}
   /**dyadic adverb     */ #[derive(DBG      )] pub enum Yd{/**dyadic `/` */      Table ,
                                                            /**dyadic `\` */      Infix }
   /**monadic adverb    */ #[derive(DBG      )] pub enum Ym{/**monadic `/`*/      Insert,
@@ -104,7 +104,7 @@ mod lex{use crate::*;
 
   impl M {fn new(s:&str)->O<M> {use M::*; Some(match s{"i."=>Idot  ,"$" =>Shape ,"|:"=>Transpose  ,
                                                        "#" =>Tally ,"[" =>Same  ,"]" =>Same       ,
-                                                                                    _=>r!(None)})}}
+                                                       ">:"=>Inc,                   _=>r!(None)})}}
   impl D {fn new(s:&str)->O<D> {use D::*; Some(match s{"+" =>Plus  ,"*" =>Mul   ,"[" =>Left       ,
                                                        "]" =>Right ,                _=>r!(None)})}}
   impl Ym{fn new(s:&str)->O<Ym>{use Ym::*;Some(match s{"/" =>Insert,"\\"=>Prefix,   _=>r!(None)})}}

--- a/tests/t.rs
+++ b/tests/t.rs
@@ -15,6 +15,10 @@
   #[test]fn add_slice_to_rotated_slice()->R<()>{
     let(a@A{m:4,n:1,..})=eval_s("1 2 3 4 + i. 4 1")? else{bail!("bad dims")};eq!(a.into_matrix()?,&[&[1],&[3],&[5],&[7]]);ok!()}
   #[test]fn other_add_slice_to_rotated_slice_is_length_error()->R<()>{is!(eval_s("i. 4 1 + 1 2 3 4").is_err());ok!()}
+} #[cfg(test)]mod increment{use super::*;
+  #[test]fn increment_scalar()->R<()>{let(i)=eval_s(">: 1")?;     eq!(i.as_i()?,       2);               ok!()}
+  #[test]fn increment_slice ()->R<()>{let(i)=eval_s(">: 1 2 3")?; eq!(i.as_slice()?,   &[2,3,4]);        ok!()}
+  #[test]fn increment_matrix()->R<()>{let(i)=eval_s(">: i. 2 2")?;eq!(i.into_matrix()?,&[&[1,2],&[3,4]]);ok!()}
 } #[cfg(test)]mod tally{use super::*;
   macro_rules! t{($f:ident,$i:literal,$o:literal)=>{
     #[test]fn $f()->R<()>{let(a@A{m:1,n:1,..})=eval_s($i)? else{bail!("bad dims")};eq!(a.as_slice()?,&[$o]);ok!()}}}


### PR DESCRIPTION
here's a small monadic verb, whose implementation will be described in the readme.

```
; git show --oneline --quiet
62edb1f (HEAD -> add-increment, origin/add-increment) 🤠 `>:` increment operator
; cargo test --quiet

running 92 tests
........................................................................................ 88/92
....
test result: ok. 92 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 63 tests
........................ii.....................................
test result: ok. 61 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 0.01s


running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```